### PR TITLE
Attempt to fix callback URL query args in issue #3.

### DIFF
--- a/CallbackURLKit/Extensions.swift
+++ b/CallbackURLKit/Extensions.swift
@@ -38,6 +38,10 @@ extension String {
         return result
     }
 
+    var ampersandEncoded: String? {
+        let nonAmpersandCharacters = NSCharacterSet(charactersInString: "&").invertedSet
+        return self.stringByAddingPercentEncodingWithAllowedCharacters(nonAmpersandCharacters)
+    }
 }
 
 extension Dictionary {

--- a/CallbackURLKit/Manager.swift
+++ b/CallbackURLKit/Manager.swift
@@ -201,15 +201,15 @@ public class Manager {
             let xcuParams: Parameters = [kRequestID: request.ID]
             
             if request.successCallback != nil {
-                xcuComponents.query = (xcuParams + [kResponseType: ResponseType.success.rawValue]).query.ampersandEncoded
-                query[kXCUSuccess] = xcuComponents.URL?.absoluteString ?? ""
+                xcuComponents.query = (xcuParams + [kResponseType: ResponseType.success.rawValue]).query
+                query[kXCUSuccess] = xcuComponents.URL?.absoluteString.ampersandEncoded ?? ""
                 
-                xcuComponents.query = (xcuParams + [kResponseType: ResponseType.cancel.rawValue]).query.ampersandEncoded
-                query[kXCUCancel] = xcuComponents.URL?.absoluteString ?? ""
+                xcuComponents.query = (xcuParams + [kResponseType: ResponseType.cancel.rawValue]).query
+                query[kXCUCancel] = xcuComponents.URL?.absoluteString.ampersandEncoded ?? ""
             }
             if request.failureCallback != nil {
-                xcuComponents.query = (xcuParams + [kResponseType: ResponseType.error.rawValue]).query.ampersandEncoded
-                query[kXCUError] = xcuComponents.URL?.absoluteString ?? ""
+                xcuComponents.query = (xcuParams + [kResponseType: ResponseType.error.rawValue]).query
+                query[kXCUError] = xcuComponents.URL?.absoluteString.ampersandEncoded ?? ""
             }
             
             if request.hasCallback {


### PR DESCRIPTION
These changes look like they should work, but the resulting callback URL query args are now over-encoded somehow. Instead of converting each "&" to a single "%26", they get converted to "%252526" instead, meaning it's getting percent-encoded one extra time.