### PR TITLE
Fix Closure use of non-escaping parameter - Swift 3 issue

### DIFF
--- a/Sources/CallbackURLKit.swift
+++ b/Sources/CallbackURLKit.swift
@@ -27,7 +27,7 @@ import Foundation
 // action ie. url path
 public typealias Action = String
 // block which handle action and optionally respond to callback
-public typealias ActionHandler = (Parameters, SuccessCallback, FailureCallback, CancelCallback) -> Void
+public typealias ActionHandler = (Parameters, @escaping SuccessCallback, @escaping FailureCallback, @escaping CancelCallback) -> Void
 // Simple dictionary for parameters
 public typealias Parameters = [String: String]
 


### PR DESCRIPTION
related url http://stackoverflow.com/questions/40257271/closure-use-of-non-escaping-parameter-swift-3-issue